### PR TITLE
Update react-redux to fix deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "react": "^15.4.2",
     "react-addons-test-utils": "^15.4.2",
     "react-dom": "^15.4.2",
-    "react-redux": "^5.0.3",
+    "react-redux": "^5.0.6",
     "redux": "^3.6.0",
     "rimraf": "^2.6.1",
     "sinon": "^2.1.0"
@@ -61,7 +61,7 @@
   "peerDependencies": {
     "prop-types": "^15.5.8",
     "react": "^0.14.0 || ^15.0.0",
-    "react-redux": "^5.0.0"
+    "react-redux": "^5.0.6",
   },
   "dependencies": {
     "redux-intl-connect": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "peerDependencies": {
     "prop-types": "^15.5.8",
     "react": "^0.14.0 || ^15.0.0",
-    "react-redux": "^5.0.6",
+    "react-redux": "^5.0.6"
   },
   "dependencies": {
     "redux-intl-connect": "^2.2.0"


### PR DESCRIPTION
https://reactjs.org/warnings/dont-call-proptypes.html